### PR TITLE
Require Genetic Engineering for Genetics

### DIFF
--- a/data/technologies.json
+++ b/data/technologies.json
@@ -358,7 +358,7 @@
         "type": "unlocks",
         "value": {
           "type": "productTypes",
-          "value": "Genetic"
+          "value": "Genetics"
         }
       }
     ]


### PR DESCRIPTION
"Genetic Engineering" doesn't unlock anything -- Genetics is already available once Biotech is unlocked.

I think that's because of this typo, which is preventing the game from requiring "Genetic Engineering" for Genetics.