### PR TITLE
Fix colors of the auto complete button

### DIFF
--- a/css/popups.sass
+++ b/css/popups.sass
@@ -661,7 +661,7 @@ button.owned
   margin: 1em 0
   display: inline-block
 
-.task-toggle-repeat
+.task-toggle-repeat, .task-toggle-auto-complete
   background: #aaa !important
   opacity: 0.8
   &.toggled


### PR DESCRIPTION
Fixes #149.

The real reason is that #143 only changes the final css file(main.css), instead of sass source files. To avoid similar issues, I suggest to remove main.css from source control and add a npm script to build sass files.